### PR TITLE
Improve documentation around the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 xcuserdata
 /build
 Pods/
-Podfile.lock
 *.ipa
 img
 todo.md

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,92 @@
+PODS:
+  - Crashlytics (3.13.2):
+    - Fabric (~> 1.10.2)
+  - Fabric (1.10.2)
+  - Firebase/Analytics (6.3.0):
+    - Firebase/Core
+  - Firebase/Core (6.3.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 6.0.2)
+  - Firebase/CoreOnly (6.3.0):
+    - FirebaseCore (= 6.0.3)
+  - FirebaseAnalytics (6.0.2):
+    - FirebaseCore (~> 6.0)
+    - FirebaseInstanceID (~> 4.2)
+    - GoogleAppMeasurement (= 6.0.2)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 0.3)
+  - FirebaseCore (6.0.3):
+    - GoogleUtilities/Environment (~> 6.0)
+    - GoogleUtilities/Logger (~> 6.0)
+  - FirebaseInstanceID (4.2.0):
+    - FirebaseCore (~> 6.0)
+    - GoogleUtilities/Environment (~> 6.0)
+    - GoogleUtilities/UserDefaults (~> 6.0)
+  - GoogleAppMeasurement (6.0.2):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 0.3)
+  - GoogleUtilities/AppDelegateSwizzler (6.2.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.2.0)
+  - GoogleUtilities/Logger (6.2.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.2.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.2.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.2.0)"
+  - GoogleUtilities/Reachability (6.2.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (6.2.0):
+    - GoogleUtilities/Logger
+  - JPSVolumeButtonHandler (1.0.5)
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
+
+DEPENDENCIES:
+  - Crashlytics (~> 3.13.1)
+  - Fabric (~> 1.10.1)
+  - Firebase/Analytics
+  - JPSVolumeButtonHandler (~> 1.0)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Crashlytics
+    - Fabric
+    - Firebase
+    - FirebaseAnalytics
+    - FirebaseCore
+    - FirebaseInstanceID
+    - GoogleAppMeasurement
+    - GoogleUtilities
+    - JPSVolumeButtonHandler
+    - nanopb
+
+SPEC CHECKSUMS:
+  Crashlytics: 611738c7847f8291a1a51084e35987b86ba6b3ee
+  Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
+  Firebase: 8432d732974498afd5987e9001a05f90f1a3d625
+  FirebaseAnalytics: 470ddab7253b21ad5a40bebd4a9903d7ae19386a
+  FirebaseCore: 68f8a7f50cdae542715d4e86afa37c4067217dcb
+  FirebaseInstanceID: f20243a1d828e0e9a3798b995174dedc16f1b32a
+  GoogleAppMeasurement: a35a645835bae31b6bdc0576396bc23908f12a22
+  GoogleUtilities: 996e0db07153674fd1b54b220fda3a3dc3547cba
+  JPSVolumeButtonHandler: 53110330c9168ed325def93eabff39f0fe3e8082
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
+
+PODFILE CHECKSUM: cf11a7f364ef2408ef8d1b28086ee2aadefe8e17
+
+COCOAPODS: 1.7.2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 Home Movies
 ===========
+
+
+## Building
+The build is managed by xCode and CocoaPods;
+
+Note that unless you are a Zinc Core Member, you may need to change your Team and other settings in the xCode target configuration.
+### Prerequisites
+- [Download the GoogleServices-Info.plist](https://console.firebase.google.com/u/0/project/homemovies-production/settings/general/ios:com.homemoviesapp.homemovies) or generate your own
+- xCode 10.2 or greater
+- [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html) (and run `pod install`)
+
+
+### Troubleshooting
+- No account for team "5GGD34ZNFU" - This is the Zinc Core team account id; you'll want to Change the Build Settings -> Signing -> Development Team to your iOS Developer account.
+- Build input file cannot be found: '.../GoogleService-Info.plist' - Zinc Core members may [Download the GoogleServices-Info.plist](https://console.firebase.google.com/u/0/project/homemovies-production/settings/general/ios:com.homemoviesapp.homemovies). Others are encouraged to [setup their own](https://firebase.google.com/docs/ios/setup) firebase project.


### PR DESCRIPTION
After I removed the GoogleServices-Info.plist, I realized that there was probably some value in providing instructions for us on how to get the app running locally. 

